### PR TITLE
Potential fix for code scanning alert no. 95: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
+++ b/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
@@ -9,6 +9,8 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/JSTONE1111/chainlink/security/code-scanning/95](https://github.com/JSTONE1111/chainlink/security/code-scanning/95)

In general, this problem is fixed by adding an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job needing permissions. The block should request only the minimal scopes required for the workflow to function. For workflows that only need to read code, `contents: read` is often sufficient; for workflows that push commits or create tags, `contents: write` is required.

For this particular workflow, the `sync` job performs `git push origin upstream/develop:develop`, which requires write access to repository contents. It does not interact with issues, pull requests, or other resources. Therefore, the least-privilege configuration is to add `permissions: contents: write` to the `sync` job. We will edit `.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml` and insert a `permissions` block under `jobs: sync:` alongside `name:` and `runs-on:`. No imports or additional methods are needed; this is a pure YAML configuration change that does not alter the runtime logic of the steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
